### PR TITLE
Implement focus-window-or-workspace-down support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,28 @@ Mod+Right     { spawn "vim-niri-nav" "right"; }
 
 You can now use `Mod+<arrow>` to navigate among niri windows and Vim splits!
 
+
 ## Configuration
 
 The `vim-niri-nav` shell script applies a timeout to its communication with (Neo)Vim and falls back to normal `niri msg action focus-<type + direction>` commands if the timeout is exceeded. This is useful in cases where (Neo)Vim is blocked on some long-running operation and takes a long time to respond -- better to at least move to the adjacent niri window than to do nothing.
 
 The timeout is implemented using the [`timeout` program from the GNU coreutils](https://www.gnu.org/software/coreutils/timeout). If the `timeout` program is not available, no timeout will be applied. The default timeout is `0.1s` (1/10th of a second), but this can be overridden by setting the `VIM_NIRI_NAV_TIMEOUT` environment variable. Setting this variable to `0` will disable the timeout behavior, allowing (Neo)Vim to be as slow as it wants to be.
+
+### niri focus-window-or-workspace-[down|up] support
+
+If you want to use `focus-window-or-workspace-[down|up]` instead of `focus-window-[down|up]`:
+
+Set `g:vim_niri_nav_workspace` to `"true"` in your vim configuration:
+
+```
+let g:vim_niri_nav_workspace = "true"
+```
+
+Then, in your niri config add the `w` parameter to the `vim-niri-nav` command:
+
+```
+Mod+Down    { spawn "vim-niri-nav" "up" "w"; }
+```
 
 ## Contributing
 

--- a/plugin/vim-niri-nav.vim
+++ b/plugin/vim-niri-nav.vim
@@ -60,10 +60,10 @@ function VimNiriNav(dir, caller_version = 0)
     " check if vim_niri_nav_workspace is set if not set it to false
     let g:vim_niri_nav_workspace = get(g:, 'vim_niri_nav_workspace', false) 
     let l:dir_flag = get({"left": "h", "down": "j", "up": "k", "right": "l"}, a:dir)
-    if g:workspace = false
+    if g:vim_niri_nav_workspace = false
         " default behaviour focus-window-[up|down]
         let l:dir_comp = get({"left": "column", "down": "window", "up": "window", "right": "column"}, a:dir)
-    elseif g:workspace = true
+    elseif g:vim_niri_nav_workspace = true
         " focus-window-or-workspace-[up|down]
         let l:dir_comp = get({"left": "column", "down": "window-or-workspace", "up": "window-or-workspace", "right": "column"}, a:dir)
     endif

--- a/plugin/vim-niri-nav.vim
+++ b/plugin/vim-niri-nav.vim
@@ -57,9 +57,16 @@ function VimNiriNav(dir, caller_version = 0)
     if a:caller_version < 1
         call s:show_deprecation_warning()
     endif
-
+    " check if vim_niri_nav_workspace is set if not set it to false
+    let g:vim_niri_nav_workspace = get(g:, 'vim_niri_nav_workspace', false) 
     let l:dir_flag = get({"left": "h", "down": "j", "up": "k", "right": "l"}, a:dir)
-    let l:dir_comp = get({"left": "column", "down": "window", "up": "window", "right": "column"}, a:dir)
+    if g:workspace = false
+        " default behaviour focus-window-[up|down]
+        let l:dir_comp = get({"left": "column", "down": "window", "up": "window", "right": "column"}, a:dir)
+    elseif g:workspace = true
+        " focus-window-or-workspace-[up|down]
+        let l:dir_comp = get({"left": "column", "down": "window-or-workspace", "up": "window-or-workspace", "right": "column"}, a:dir)
+    endif
     if winnr(l:dir_flag) == winnr()
         if a:caller_version < 1
             call s:job(["niri", "msg", "action", "focus-" . a:dir_comp . "-" . a:dir])

--- a/plugin/vim-niri-nav.vim
+++ b/plugin/vim-niri-nav.vim
@@ -58,12 +58,12 @@ function VimNiriNav(dir, caller_version = 0)
         call s:show_deprecation_warning()
     endif
     " check if vim_niri_nav_workspace is set if not set it to false
-    let g:vim_niri_nav_workspace = get(g:, 'vim_niri_nav_workspace', false) 
+    let g:vim_niri_nav_workspace = get(g:, "vim_niri_nav_workspace", "false") 
     let l:dir_flag = get({"left": "h", "down": "j", "up": "k", "right": "l"}, a:dir)
-    if g:vim_niri_nav_workspace = false
+    if g:vim_niri_nav_workspace == "false"
         " default behaviour focus-window-[up|down]
         let l:dir_comp = get({"left": "column", "down": "window", "up": "window", "right": "column"}, a:dir)
-    elseif g:vim_niri_nav_workspace = true
+    elseif g:vim_niri_nav_workspace == "true"
         " focus-window-or-workspace-[up|down]
         let l:dir_comp = get({"left": "column", "down": "window-or-workspace", "up": "window-or-workspace", "right": "column"}, a:dir)
     endif

--- a/vim-niri-nav
+++ b/vim-niri-nav
@@ -4,6 +4,13 @@
 # vim splits. Requires the accompanying vim plugin.
 
 dir="$1"
+if [ -n "$2" ]; then
+    if [ $2 = "w" ]; then
+        custom="or-workspace-"
+    else
+        custom=""
+    fi 
+fi
 timeout="${VIM_NIRI_NAV_TIMEOUT:-0.1s}"
 
 case "$dir" in
@@ -72,7 +79,7 @@ fi
 
 case "$dir" in
 up | down)
-  niri msg action focus-window-$dir
+  niri msg action focus-window-$custom$dir
   ;;
 *)
   niri msg action focus-column-$dir


### PR DESCRIPTION
This PR implements support for niri's focus-window-or-workspace-[down|up] command.
in vim the var `g:vim_niri_nav_workspace` can be set to `"true"` to use the command (for backward compatiblity, if I understood the plugin correctly)
For the script to work: simply pass `"w"` as a second argument like so:

```
Mod+Down    { spawn "vim-niri-nav" "up" "w"; }
```

This is my first time writing/modifying an existing vimscript so hopefully I didn't miss anything.
I've tested it on my end and as far as I can tell it works properly.
The variables names could probably be better but I was lacking inspiration.
This also fixes #1 