### PR TITLE
add support for focus-window-or-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,15 @@ let g:vim_niri_nav_workspace = "true"
 Then, in your niri config add the `w` parameter to the `vim-niri-nav` command:
 
 ```
-Mod+Down    { spawn "vim-niri-nav" "up" "w"; }
+Mod+Down    { spawn "vim-niri-nav" "down" "w"; }
+```
+
+### niri focus-window-or-monitor-[down|up] support
+
+In your niri config add the `m` parameter to the `vim-niri-nav` command:
+
+```
+Mod+Down    { spawn "vim-niri-nav" "down" "m"; }
 ```
 
 ## Contributing

--- a/vim-niri-nav
+++ b/vim-niri-nav
@@ -7,6 +7,8 @@ dir="$1"
 if [ -n "$2" ]; then
     if [ $2 = "w" ]; then
         custom="or-workspace-"
+    elif [ $2 = "m" ]; then
+        custom="or-monitor-"
     else
         custom=""
     fi 


### PR DESCRIPTION
I also fixed the example config for `focus-window-or-workspace` so that the bind was the right way round (was binding up to down)